### PR TITLE
Include resin in net trade

### DIFF
--- a/sql/09_export/export.sql
+++ b/sql/09_export/export.sql
@@ -58,7 +58,8 @@ FROM
             (
                 netImportArticlesMT +
                 netImportFibersMT +
-                netImportGoodsMT
+                netImportGoodsMT +
+                netImportResinMT
             ) AS netImport,
             (
                 consumptionAgricultureMT +


### PR DESCRIPTION
To allow for easier calculations with GHG, have production assigned to exporter for resin trade. Will allow user to configure further in tool.